### PR TITLE
Implement type hints tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,18 @@ jobs:
           echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
           ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
 
+      # Run tests
+      - name: Run Tests
+        run: ./gradlew test
+
+      # Collect Tests Result of failed tests
+      - name: Collect Tests Result
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-result
+          path: ${{ github.workspace }}/build/reports/tests
+
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
         uses: actions/cache@v3

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/PythonAbstractInlayHintsTestCase.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/PythonAbstractInlayHintsTestCase.kt
@@ -1,0 +1,10 @@
+package space.whitememory.pythoninlayparams
+
+import com.intellij.testFramework.utils.inlays.InlayHintsProviderTestCase
+import com.jetbrains.python.psi.LanguageLevel
+import space.whitememory.pythoninlayparams.python.PyLightProjectDescriptor
+
+
+abstract class PythonAbstractInlayHintsTestCase : InlayHintsProviderTestCase() {
+    override fun getProjectDescriptor() = PyLightProjectDescriptor(LanguageLevel.getLatest())
+}

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/PythonFunctionReturnTypesTest.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/PythonFunctionReturnTypesTest.kt
@@ -20,6 +20,11 @@ class PythonFunctionReturnTypesTest : PythonAbstractInlayHintsTestCase() {
             
         def get_union()<# [->  [int  |  str]] #>:
             return 1 or ""
+            
+       def get_optional()<# [->  [[list [ A ]]  |  None]] #>:
+            if True:
+                return [A()]
+            return None
     """.trimIndent()
     )
 

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/PythonFunctionReturnTypesTest.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/PythonFunctionReturnTypesTest.kt
@@ -1,0 +1,173 @@
+package space.whitememory.pythoninlayparams
+
+import space.whitememory.pythoninlayparams.types.functions.PythonFunctionInlayTypeHintsProvider
+
+class PythonFunctionReturnTypesTest : PythonAbstractInlayHintsTestCase() {
+
+    fun testSimple() = doTest(
+        """
+        class A:
+            ...
+
+        def get_int()<# [->  int] #>:
+            return 1
+            
+        def get_instance()<# [->  A] #>:
+            return A()
+            
+        def get_type()<# [->  [Type [ A ]]] #>:
+            return A
+            
+        def get_union()<# [->  [int  |  str]] #>:
+            return 1 or ""
+    """.trimIndent()
+    )
+
+    fun testNoHint() = doTest(
+        """
+        def get_implicit_none():
+            return
+        
+        def get_explicit_none():
+            return None
+            
+        def check_ellipsis():
+            ...
+        
+        def check_pass():
+            pass
+            
+        async def async_get_implicit_none():
+            return
+        
+        async def async_get_explicit_none():
+            return None
+            
+        async def async_check_ellipsis():
+            ...
+        
+        async def async_check_pass():
+            pass
+            
+        def check_filled_hint() -> str:
+            return ""
+ 
+        def async_check_filled_hint() -> str:
+            return ""
+    """.trimIndent()
+    )
+
+    fun testCollections() = doTest(
+        """
+        class A:
+            ...
+            
+        def get_set()<# [->  [set [ str ]]] #>:
+            return {"foo", "bar"}
+            
+        def get_tuple()<# [->  [tuple [ int ,  A ]]] #>:
+            return 1, A()
+        
+        def get_nested_tuples()<# [->  [tuple [ [tuple [ int ,  int ]] ,  [tuple [ int ,  int ]] ]]] #>:
+            return ((1, 1), (1, 1))
+            
+        def get_list_any()<# [->  list] #>:
+            return []
+            
+        def get_list_of_union_types()<# [->  [list [ [A  |  int] ]]] #>:
+            return [A(), 1]
+    """.trimIndent()
+    )
+
+    fun testDictionaries() = doTest(
+        """    
+        def get_dict_any()<# [->  dict] #>:
+            return {}
+            
+        def get_dict_single()<# [->  [dict [ str ,  int ]]] #>:
+            return {"": 1}
+            
+        def get_dict_union()<# [->  [dict [ str ,  [str  |  int] ]]] #>:
+            return {"foo": 1, "bar": ""}
+            
+        def get_nested_dict()<# [->  [dict [ int ,  [dict [ str ,  str ]] ]]] #>:
+            return {1: {"": ""}}
+    """.trimIndent()
+    )
+
+    fun testAsync() = doTest(
+        """
+        async def coro()<# [->  int] #>:
+            return 1
+            
+        async def get_coro()<# [->  [Coroutine [ Any ,  Any ,  int ]]] #>:
+            return coro()
+            
+        async def get_coro_result()<# [->  int] #>:
+            return await coro()
+            
+        async def test_nested_coro<# [->  [Coroutine [ Any ,  Any ,  [Coroutine [ Any ,  Any ,  int ]] ]]] #>:
+            return get_coro()
+    """.trimIndent()
+    )
+
+    fun testGenerators() = doTest(
+        """
+        def sync_generator()<# [->  [Generator [ int ,  Any ,  list ]]] #>:
+            for i in range(10):
+                yield i
+                
+            return []
+            
+        async def async_generator()<# [->  [AsyncGenerator [ int ,  Any ]]] #>:
+            for i in range(10):
+                yield i
+    """.trimIndent()
+    )
+
+    fun testClassMethods() = doTest(
+        """
+        class A:
+            def check_method_hint()<# [->  int] #>:
+                return 1
+                
+            def check_not_return():
+                pass
+    """.trimIndent()
+    )
+
+    fun testCallable() = doTest(
+        """
+        def test_callable(foo: int, bar: str) -> int:
+            return 1
+        
+        def get_callable()<# [->  [(foo: int, bar: str)  ->  ( int )]] #>:
+            return test_callable
+            
+        def get_lambda()<# [->  [(x, y)  ->  ( Any )]] #>:
+            return lambda x, y: x * y
+    """.trimIndent()
+    )
+
+    fun testIncompleteDefs() = doTest(
+        """
+        def
+        
+        def test  
+              
+        def test()
+        
+        def test:
+        
+        def test() ->
+        
+        def test() ->:
+    """.trimIndent()
+    )
+
+    private fun doTest(text: String) {
+        testProvider(
+            "foo.py", text, PythonFunctionInlayTypeHintsProvider()
+        )
+    }
+}

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/PythonInlayHintsTest.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/PythonInlayHintsTest.kt
@@ -1,4 +1,0 @@
-package space.whitememory.pythoninlayparams
-
-class PythonInlayHintsTest {
-}

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/PythonVariableTypesTest.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/PythonVariableTypesTest.kt
@@ -1,0 +1,180 @@
+package space.whitememory.pythoninlayparams
+
+import space.whitememory.pythoninlayparams.types.variables.PythonVariablesInlayTypeHintsProvider
+
+class PythonVariableTypesTest : PythonAbstractInlayHintsTestCase() {
+    private val testObjects = """
+        import datetime
+        from typing import Union, TypedDict
+
+        def get_int():
+            return 1
+            
+        class TestTyped(TypedDict):
+            id: int
+            name: str
+            
+        class UnionChild(Union):
+            ...
+
+        class A:
+            def __init__(self, val: int):
+                self.val = val
+
+            @classmethod
+            def from_val(cls, val: int) -> "A":
+                return cls(val)
+                
+        def get_a():
+            return A()
+        
+        def get_a_type():
+            return A
+                
+        def get_optional():
+            if True:
+                return [A(1)]
+        
+            return None
+            
+        def get_callable():
+            return get_int
+            
+        def get_lambda():
+            return lambda x, y: x * y
+            
+        def get_typed_dict() -> TestTyped:
+            return {"id": 1, name: "test"}
+            
+        async def coro():
+            return 1
+            
+        async def get_coro():
+            return coro()
+            
+        def get_now():
+            return datetime.datetime.now()
+    """.trimIndent()
+
+    fun testSimple() = doTest(
+        """
+        x1<# [:  int] #> = get_int()
+        x2<# [:  [[list [ A ]]  |  None]] #> = get_optional()
+        x3<# [:  TestTyped] #> = get_typed_dict()
+        
+        x7<# [:  [A  |  None]] #> = A() or None
+        x8<# [:  [A  |  None]] #> = A() and None
+        x9<# [:  A] #> = A() or get_a()
+        x10<# [:  [A  |  None]] #> = get_a() or None
+        x11<# [:  [A  |  None]] #> = A.from_val(10) or None
+        x12<# [:  [[Type [ A ]]  |  A]] #> = get_a_type() or A()
+        x13<# [:  [Type [ A ]]] #> = get_a_type()
+        
+        b1<# [:  datetime] #> = get_now()
+    """.trimIndent()
+    )
+
+    fun testNoHint() = doTest(
+        """
+        x1 = 1
+        x2 = -1
+        x3 = +1
+        x4 = 1_000
+        x5 = 1 or 2
+        x6 = 1 and 2
+        x7 = 1 if True else 1
+        x8 = 1 + 1
+        x9 = 1 - 1
+ 
+        b = (111)
+        c = (1,)
+        d = ("1", "2", 3)
+        e = []
+            
+        f: int = get_int()
+        # g1 = A
+        g2 = A(1)
+        g3 = A(1) or A(2)
+        g4 = A.from_val(1)
+        g5 = Union[int, str]
+        # g6 = UnionChild[int, str]
+        g7 = {k: None for k, _ in range(10)}
+        
+        h1 = datetime.datetime.now()
+        h2 = datetime.datetime()
+    """.trimIndent()
+    )
+
+    fun testReassignments() = doTest(
+        """
+        x<# [:  [Coroutine [ Any ,  Any ,  int ]]] #> = coro()
+        y<# [:  [Coroutine [ Any ,  Any ,  int ]]] #> = x
+        z<# [:  int] #> = await x
+        
+        f = 1
+        g = f
+        h<# [:  int] #> = 1 + g
+    """.trimIndent()
+    )
+
+    fun testComplex() = doTest(
+        """
+        x1<# [:  [[list [ A ]]  |  None  |  list  | ...]] #> = get_optional() or [] or {}
+        long_types<# [:  [list [ [int  |  [list [ [list  |  int  | ...] ]]  | ...] ]]] #> = [1, [[], 1, '3'], '', []]
+        
+        coro_callable<# [:  [()  ->  ( [Coroutine [ Any ,  Any ,  int ]] )]] #> = coro
+        one_coro<# [:  [Coroutine [ Any ,  Any ,  int ]]] #> = await get_coro()
+        nested_coro<# [:  [Coroutine [ Any ,  Any ,  [Coroutine [ Any ,  Any ,  int ]] ]]] #> = get_coro()
+        coro_value<# [:  int] #> = await one_coro
+        
+        x4<# [:  [()  ->  ( int )]] #> = get_callable()
+        x5<# [:  [(x, y)  ->  ( Any )]] #> = get_lambda()
+        x6<# [:  [(val: int)  ->  ( A )]] #> = A.from_val
+        
+        def get_generator():
+            for i<# [:  int] #> in range(10):
+                yield i
+            return []
+        
+        async def get_async_generator():
+            for i<# [:  int] #> in range(10):
+                yield i
+        
+        g1<# [:  [Generator [ int ,  Any ,  list ]]] #> = get_generator()
+        g2<# [:  [AsyncGenerator [ int ,  Any ]]] #> = get_async_generator()
+    """.trimIndent()
+    )
+
+    fun testClassAttrs() = doTest(
+        """
+        class TestAttrs:
+            x<# [:  int] #> = get_int()
+            y<# [:  [[list [ A ]]  |  None]] #> = get_optional()
+            x = 1
+    """.trimIndent()
+    )
+
+    fun testLoopHints() = doTest(
+        """
+        dt = {"test": 1}
+        
+        d3 = {u: n for u<# [:  str] #>, n<# [:  int] #> in dt.items()}
+        d<# [:  [list [ int ]]] #> = [i for i<# [:  int] #> in range(10)]
+        s2 = {i for i<# [:  int] #> in range(10)}
+        d2 = {k: v for k<# [:  str] #>, v<# [:  int] #> in {"a": 1, "b": 2}.items()}
+        c<# [:  [list [ A ]]] #> = [get_a() for i<# [:  int] #> in range(10)]
+        s = {get_a_type() for i<# [:  int] #> in range(10)}
+        v = {k: get_a() for k<# [:  int] #> in range(10)}
+        s1<# [:  [frozenset [ A ]]] #> = frozenset(get_a() for i<# [:  int] #> in range(10))
+    """.trimIndent()
+    )
+
+    private fun doTest(text: String) {
+        testProvider(
+            "foo.py",
+            "$testObjects\n$text",
+            PythonVariablesInlayTypeHintsProvider(),
+            PythonVariablesInlayTypeHintsProvider.Settings(showClassAttributeHints = true, showGeneralHints = true)
+        )
+    }
+}

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/python/PyLightProjectDescriptor.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/python/PyLightProjectDescriptor.kt
@@ -1,0 +1,20 @@
+package space.whitememory.pythoninlayparams.python
+
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.LightProjectDescriptor
+import com.jetbrains.python.psi.LanguageLevel
+
+
+class PyLightProjectDescriptor private constructor(private val myName: String?, private val myLevel: LanguageLevel) :
+    LightProjectDescriptor() {
+    constructor(level: LanguageLevel) : this(null, level)
+
+    override fun getSdk(): Sdk {
+        return if (myName == null) PythonMockSdk.create(myLevel, *additionalRoots) else PythonMockSdk.create(myName)
+    }
+
+    private val additionalRoots: Array<VirtualFile>
+        get() = VirtualFile.EMPTY_ARRAY
+
+}

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/python/PythonMockSdk.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/python/PythonMockSdk.kt
@@ -1,0 +1,99 @@
+package space.whitememory.pythoninlayparams.python
+
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkAdditionalData
+import com.intellij.openapi.projectRoots.SdkTypeId
+import com.intellij.openapi.projectRoots.impl.MockSdk
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.containers.ContainerUtil
+import com.intellij.util.containers.MultiMap
+import com.jetbrains.python.PyNames
+import com.jetbrains.python.codeInsight.typing.PyTypeShed.findRootsForLanguageLevel
+import com.jetbrains.python.codeInsight.userSkeletons.PyUserSkeletonsUtil
+import com.jetbrains.python.psi.LanguageLevel
+import com.jetbrains.python.sdk.PythonSdkUtil
+import org.jdom.Element
+import org.jetbrains.annotations.NonNls
+import java.io.File
+
+
+object PythonMockSdk {
+    fun create(name: String): Sdk {
+        return create(name, LanguageLevel.getLatest())
+    }
+
+    fun create(level: LanguageLevel, vararg additionalRoots: VirtualFile): Sdk {
+        return create("MockSdk", level, *additionalRoots)
+    }
+
+    private fun create(name: String, level: LanguageLevel, vararg additionalRoots: VirtualFile): Sdk {
+        return create(name, PyMockSdkType(level), level, *additionalRoots)
+    }
+
+    private fun create(
+        pathSuffix: String,
+        sdkType: SdkTypeId,
+        level: LanguageLevel,
+        vararg additionalRoots: VirtualFile
+    ): Sdk {
+        val sdkName = "Mock " + PyNames.PYTHON_SDK_ID_NAME + " " + level.toPythonVersion()
+        return create(sdkName, pathSuffix, sdkType, level, *additionalRoots)
+    }
+
+    private fun create(
+        name: String,
+        pathSuffix: String,
+        sdkType: SdkTypeId,
+        level: LanguageLevel,
+        vararg additionalRoots: VirtualFile
+    ): Sdk {
+        val mockSdkPath = "testData/$pathSuffix"
+        val roots = MultiMap.create<OrderRootType, VirtualFile>()
+        roots.putValues(OrderRootType.CLASSES, createRoots(mockSdkPath, level))
+        roots.putValues(OrderRootType.CLASSES, listOf(*additionalRoots))
+        val sdk = MockSdk(
+            name,
+            "$mockSdkPath/bin/python",
+            toVersionString(level),
+            roots,
+            sdkType
+        )
+
+        // com.jetbrains.python.psi.resolve.PythonSdkPathCache.getInstance() corrupts SDK, so have to clone
+        return sdk.clone()
+    }
+
+    private fun createRoots(@NonNls mockSdkPath: String, level: LanguageLevel): List<VirtualFile> {
+        val result = ArrayList<VirtualFile>()
+        val localFS = LocalFileSystem.getInstance()
+        ContainerUtil.addIfNotNull(result, localFS.refreshAndFindFileByIoFile(File(mockSdkPath, "Lib")))
+        ContainerUtil.addIfNotNull(
+            result,
+            localFS.refreshAndFindFileByIoFile(File(mockSdkPath, PythonSdkUtil.SKELETON_DIR_NAME))
+        )
+        ContainerUtil.addIfNotNull(result, PyUserSkeletonsUtil.getUserSkeletonsDirectory())
+        result.addAll(findRootsForLanguageLevel(level))
+        return result
+    }
+
+    private fun toVersionString(level: LanguageLevel): String {
+        return "Python " + level.toPythonVersion()
+    }
+
+    private class PyMockSdkType(private val myLevel: LanguageLevel) : SdkTypeId {
+        override fun getName(): String {
+            return PyNames.PYTHON_SDK_ID_NAME
+        }
+
+        override fun getVersionString(sdk: Sdk): String {
+            return toVersionString(myLevel)
+        }
+
+        override fun saveAdditionalData(additionalData: SdkAdditionalData, additional: Element) {}
+        override fun loadAdditionalData(currentSdk: Sdk, additional: Element): SdkAdditionalData? {
+            return null
+        }
+    }
+}


### PR DESCRIPTION
To dive deeper into the type hints and refactor their code as we need, tests have become essential. This PR implements them.

### Progress
- [x] Adjust the CI/CD to run tests automatically
- [x] Implement function return types tests
- [x] Implement variables types tests