### PR TITLE
Fix unsafe cast causing issues with set[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Incorrect `Literal` behavior with type hints
+- `set[]` type hint were causing exceptions when declared explicitly
 
 ## [0.3.1] - 2022-10-02
 ### Fixed

--- a/src/main/kotlin/space/whitememory/pythoninlayparams/types/hints/HintGenerator.kt
+++ b/src/main/kotlin/space/whitememory/pythoninlayparams/types/hints/HintGenerator.kt
@@ -4,9 +4,7 @@ package space.whitememory.pythoninlayparams.types.hints
 
 import com.intellij.psi.PsiElement
 import com.jetbrains.python.PyNames
-import com.jetbrains.python.codeInsight.typing.PyTypingTypeProvider
 import com.jetbrains.python.psi.PyElement
-import com.jetbrains.python.psi.PyFunction
 import com.jetbrains.python.psi.PyLambdaExpression
 import com.jetbrains.python.psi.types.*
 

--- a/src/main/kotlin/space/whitememory/pythoninlayparams/types/hints/HintResolver.kt
+++ b/src/main/kotlin/space/whitememory/pythoninlayparams/types/hints/HintResolver.kt
@@ -270,8 +270,8 @@ enum class HintResolver {
                 return resolvedClass.name != typeAnnotation?.name
             }
 
-            return typeAnnotation?.isBuiltin == true
-                    && (typeAnnotation as PyCollectionType).elementTypes.filterNotNull().isNotEmpty()
+            val collectionType = (typeAnnotation as? PyCollectionType) ?: return false
+            return collectionType.isBuiltin && collectionType.elementTypes.filterNotNull().isNotEmpty()
         }
     },
 

--- a/src/main/kotlin/space/whitememory/pythoninlayparams/types/hints/HintResolver.kt
+++ b/src/main/kotlin/space/whitememory/pythoninlayparams/types/hints/HintResolver.kt
@@ -264,6 +264,8 @@ enum class HintResolver {
 
             if (assignmentValue !is PyCallExpression) return true
 
+            if (typeAnnotation is PyNoneType) return true
+
             val resolvedClass = PyCallExpressionHelper.resolveCalleeClass(assignmentValue) ?: return true
 
             if (!collectionNames.contains(resolvedClass.name)) {

--- a/src/test/kotlin/space/whitememory/pythoninlayparams/PythonVariableTypesTest.kt
+++ b/src/test/kotlin/space/whitememory/pythoninlayparams/PythonVariableTypesTest.kt
@@ -183,6 +183,19 @@ class PythonVariableTypesTest : PythonAbstractInlayHintsTestCase() {
     """.trimIndent()
     )
 
+    fun testIterableHints() = doTest(
+        """
+        item_set<# [:  [set [ str ]]] #> = set()
+        x<# [:  None] #> = item_set.add("1")
+        
+        explicit_item_set: set[str] = set()
+        y<# [:  None] #> = explicit_item_set.add("1")
+        
+        unclear_item_set: set = set()
+        z<# [:  None] #> = unclear_item_set.add("1")
+    """.trimIndent()
+    )
+
     private fun doTest(text: String) {
         testProvider(
             "foo.py",


### PR DESCRIPTION
Fixes #29

An unsafe cast in type hints was causing exceptions with `set` that declared explicitly.