### PR TITLE
Add an option to show single hints

### DIFF
--- a/src/main/resources/inlayProviders/Parameters/hints.single.parameters.py
+++ b/src/main/resources/inlayProviders/Parameters/hints.single.parameters.py
@@ -1,0 +1,5 @@
+def give_age(age: int) -> str:
+    return f"Your age is {age}"
+
+give_age(16)
+give_age(age=16)


### PR DESCRIPTION
Fixes #36. Well, somewhat fixes. A new setting for those who might prefer to always see the parameter hints, off by default.